### PR TITLE
Use default/localized name for new desktops

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -22,7 +22,7 @@ const isKde6 = typeof workspace.windowList === "function";
 const compat = isKde6
 	?
 		{ addDesktop = () =>
-			{ workspace.createDesktop(workspace.desktops.length, "dyndesk"); }
+			{ workspace.createDesktop(workspace.desktops.length, undefined); }
 		, windowAddedSignal = ws => ws.windowAdded
 		, windowList = ws => ws.windowList()
 		, desktopChangedSignal = c => c.desktopsChanged


### PR DESCRIPTION
As of https://github.com/maurges/dynamic_workspaces/issues/13 .

(ref: https://github.com/maurges/dynamic_workspaces/issues/10#issuecomment-2051284370 )

Seems to work as intended.