### PR TITLE
Configuration option to keep empty desktops between occupied ones

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0
+      http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
+  <kcfgfile name=""/>
+
+  <group name="">
+    <entry name="keepEmptyMiddleDesktops" type="Bool">
+      <default>false</default>
+    </entry>
+  </group>
+
+</kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>KWin::DynamicWorkspacesConfigForm</class>
+ <widget class="QWidget" name="KWin::DynamicWorkspacesConfigForm">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>200</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dynamic Workspaces</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+      <widget class="QCheckBox" name="kcfg_keepEmptyMiddleDesktops">
+        <property name="text">
+          <string>Keep empty desktops between occupied ones</string>
+        </property>
+      </widget>
+    </item>
+  </layout>
+ </widget>
+ <resources/>
+ </ui>

--- a/metadata.json
+++ b/metadata.json
@@ -19,4 +19,5 @@
 
 , "X-KDE-Library": "kwin/effects/configs/kcm_kwin4_genericscripted"
 , "X-Plasma-MainScript": "code/main.js"
+, "X-KDE-ConfigModule": "kwin/effects/configs/kcm_kwin4_genericscripted"
 }


### PR DESCRIPTION
This PR introduces a configuration option, `keepEmptyMiddleDesktops`, which modifies how empty desktops are cleaned up when switching workspaces.  

### Current Behavior 
- When moving from right to left, all empty desktops between the current one and the last desktop are removed.  
- This can be inconvenient if a user accidentally moves the only window from the current desktop to the left — restoring the layout requires manually shifting all windows back.  

### New Behavior
- Added configuration with **"Keep empty desktops between occupied ones"** checkbox
- When enabled, empty desktops are only removed up to the first occupied desktop encountered (going right to left).  
- The default setting remains **disabled** to maintain backward compatibility.  

### Technical Implementation
- Added user configuration, including:
  - `keepEmptyMiddleDesktops` boolean option in `main.xml`.  
  - Corresponding checkbox in `config.ui`.  
- Modified the desktop clean-up logic to respect this setting, stopping removal when a non-empty desktop is found.  
- Simplified the clean-up loop logic. All the intended behaviour should be preserved.  