### PR TITLE
Configuration option for minimum desktop count

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -6,7 +6,8 @@
 // Desktop numbers are from zero (unlike how it worked in plasma 5)
 
 
-const MIN_DESKTOPS = 2;
+const MIN_DESKTOPS = readConfig("minDesktops", 2);
+const KEEP_EMPTY_MIDDLE_DESKTOPS = readConfig("keepEmptyMiddleDesktops", false);
 const LOG_LEVEL = 2; // 0 trace, 1 debug, 2 info
 
 
@@ -238,7 +239,6 @@ function onDesktopSwitch(oldDesktop)
 	const oldDesktopIndex = compat.findDesktop(allDesktops, compat.toDesktop(oldDesktop));
 	const currentDesktopIndex = compat.findDesktop(allDesktops, compat.toDesktop(workspace.currentDesktop));
 	const getDesktopsLength = () => compat.workspaceDesktops().length;
-	const keepEmptyMiddleDesktops = readConfig("keepEmptyMiddleDesktops", false);
 
 	if (oldDesktopIndex <= currentDesktopIndex)
 	{
@@ -246,19 +246,28 @@ function onDesktopSwitch(oldDesktop)
 		return;
 	}
 
+	// Calculate the index of the last desktop we want to preserve when cleaning up.
+	// We need to preserve:
+	//   1. The current desktop (currentDesktopIndex)
+	//   2. At least MIN_DESKTOPS. Note we actually subtract two because:
+	//      - We always have the dynamic empty desktop at the end 
+	//      - MIN_DESKTOPS is a count, but we need an index
+	const preserveUpToIndex = Math.max(currentDesktopIndex, MIN_DESKTOPS - 2);
+	
 	// Loop through desktops right-to-left and delete empty ones:
 	// - Starts from second-to-last desktop (preserving always one empty desktop at the end)
 	// - Stops before reaching current desktop (preserves what user is viewing)
-	// - Extra check (desktopIdx > 0) prevents an infinite loop caused by abnormal conditions
-	//   In case of interference with other plugins, we'll only examine as many desktops as we initially detect
-	for (let desktopIdx = getDesktopsLength() - 2; desktopIdx > currentDesktopIndex && desktopIdx > 0; --desktopIdx)
+	// - Stops before reaching minimum number of desktops
+	// To prevent an infinite loop caused by abnormal conditions (e.g. interference with other plugins),
+	// we only examine as many desktops as we initially detect.
+	for (let desktopIdx = getDesktopsLength() - 2; desktopIdx > preserveUpToIndex; --desktopIdx)
 	{
 		debug(`Examine desktop ${desktopIdx}`);
 		if (isEmptyDesktop(desktopIdx))
 		{
 			removeDesktop(desktopIdx);
 		}
-		else if (keepEmptyMiddleDesktops)
+		else if (KEEP_EMPTY_MIDDLE_DESKTOPS)
 		{
 			debug("Found non-empty desktop, stopping purge");
 			break;

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -5,9 +5,6 @@
 
 // Desktop numbers are from zero (unlike how it worked in plasma 5)
 
-
-const MIN_DESKTOPS = readConfig("minDesktops", 2);
-const KEEP_EMPTY_MIDDLE_DESKTOPS = readConfig("keepEmptyMiddleDesktops", false);
 const LOG_LEVEL = 2; // 0 trace, 1 debug, 2 info
 
 
@@ -99,6 +96,11 @@ const compat = isKde6
 
 /*****  Logic definition  *****/
 
+// Wrappers for reading config values
+// This keeps default values in one place, 
+// which are also needed for readConfig to correctly derive the type
+function getMinDesktops() {return readConfig("minDesktops", 2);}
+function getKeepEmptyMiddleDesktops() {return readConfig("keepEmptyMiddleDesktops", false);}
 
 // shifts a window to the left if it's more to the right than number
 function shiftRighterThan(client, number)
@@ -147,7 +149,7 @@ function removeDesktop(number)
 		debug("Not removing desktop at end");
 		return false;
 	}
-	if (desktopsLength <= MIN_DESKTOPS)
+	if (desktopsLength <= getMinDesktops())
 	{
 		debug("Not removing desktop, too few left");
 		return false;
@@ -252,7 +254,7 @@ function onDesktopSwitch(oldDesktop)
 	//   2. At least MIN_DESKTOPS. Note we actually subtract two because:
 	//      - We always have the dynamic empty desktop at the end 
 	//      - MIN_DESKTOPS is a count, but we need an index
-	const preserveUpToIndex = Math.max(currentDesktopIndex, MIN_DESKTOPS - 2);
+	const preserveUpToIndex = Math.max(currentDesktopIndex, getMinDesktops() - 2);
 	
 	// Loop through desktops right-to-left and delete empty ones:
 	// - Starts from second-to-last desktop (preserving always one empty desktop at the end)
@@ -267,7 +269,7 @@ function onDesktopSwitch(oldDesktop)
 		{
 			removeDesktop(desktopIdx);
 		}
-		else if (KEEP_EMPTY_MIDDLE_DESKTOPS)
+		else if (getKeepEmptyMiddleDesktops())
 		{
 			debug("Found non-empty desktop, stopping purge");
 			break;

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -5,9 +5,6 @@
 
 // Desktop numbers are from zero (unlike how it worked in plasma 5)
 
-
-const MIN_DESKTOPS = readConfig("minDesktops", 2);
-const KEEP_EMPTY_MIDDLE_DESKTOPS = readConfig("keepEmptyMiddleDesktops", false);
 const LOG_LEVEL = 2; // 0 trace, 1 debug, 2 info
 
 
@@ -124,6 +121,11 @@ const compat = isKde6
 
 /*****  Logic definition  *****/
 
+// Wrappers for reading config values
+// This keeps default values in one place, 
+// which are also needed for readConfig to correctly derive the type
+function getMinDesktops() {return readConfig("minDesktops", 2);}
+function getKeepEmptyMiddleDesktops() {return readConfig("keepEmptyMiddleDesktops", false);}
 
 // shifts a window to the left if it's more to the right than number
 function shiftRighterThan(client, number)
@@ -175,7 +177,7 @@ function removeDesktop(number)
 		debug("Not removing desktop at end");
 		return false;
 	}
-	if (desktopsLength <= MIN_DESKTOPS)
+	if (desktopsLength <= getMinDesktops())
 	{
 		debug("Not removing desktop, too few left");
 		return false;
@@ -282,7 +284,7 @@ function onDesktopSwitch(oldDesktop)
 	//   2. At least MIN_DESKTOPS. Note we actually subtract two because:
 	//      - We always have the dynamic empty desktop at the end 
 	//      - MIN_DESKTOPS is a count, but we need an index
-	const preserveUpToIndex = Math.max(currentDesktopIndex, MIN_DESKTOPS - 2);
+	const preserveUpToIndex = Math.max(currentDesktopIndex, getMinDesktops() - 2);
 	
 	// Loop through desktops right-to-left and delete empty ones:
 	// - Starts from second-to-last desktop (preserving always one empty desktop at the end)
@@ -297,7 +299,7 @@ function onDesktopSwitch(oldDesktop)
 		{
 			removeDesktop(desktopIdx);
 		}
-		else if (KEEP_EMPTY_MIDDLE_DESKTOPS)
+		else if (getKeepEmptyMiddleDesktops())
 		{
 			debug("Found non-empty desktop, stopping purge");
 			break;

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -9,6 +9,11 @@
     <entry name="keepEmptyMiddleDesktops" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="minDesktops" type="UInt">
+      <default>2</default>
+      <min>2</min> <!-- One occupied desktop plus one empty dynamic desktop at the end -->
+      <max>20</max> <!-- KDE Plasma has a built-in limit of 20 virtual desktops -->
+    </entry>
   </group>
 
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -21,6 +21,24 @@
         </property>
       </widget>
     </item>
+    <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+          <widget class="QLabel" name="minDesktopsLabel">
+            <property name="text">
+              <string>Minimal number of desktops:</string>
+            </property>
+            <property name="buddy">
+              <cstring>kcfg_minDesktops</cstring>
+            </property>
+          </widget>
+        </item>
+        <item>
+          <widget class="QSpinBox" name="kcfg_minDesktops">
+          </widget>
+        </item>
+      </layout>
+    </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
Resolves #21 

---
This PR adds a new configuration option `minDesktops` that allows users to specify the minimum number of virtual desktops to preserve. Previously, the script would always clean up all empty desktops (except the first two).

The default is set to 2, which preserves the original behaviour — one regular desktop plus one empty dynamic desktop at the end. Users can now increase this value through the configuration UI if they prefer to always have more desktops available.

### Technical Implementation
- Added `minDesktops` configuration option in `main.xml`
- Created a spinner widget in `config.ui` for adjusting this setting
- Modified `main.js` to load and respect this new option
- Grouped loading of configuration constants for consistency